### PR TITLE
Add AAP workload-identity (OIDC/JWT) auth backend + role

### DIFF
--- a/auth_jwt.tf
+++ b/auth_jwt.tf
@@ -34,8 +34,8 @@ resource "vault_jwt_auth_backend_role" "tfc" {
     terraform_project_id   = "terraform_project_id"
     terraform_workspace_id = "terraform_workspace_id"
   }
-  token_ttl = 8*60*60 # 8 hours by 60 minutes by 60 seconds
-  token_period = 8*60*60
+  token_ttl    = 8 * 60 * 60 # 8 hours by 60 minutes by 60 seconds
+  token_period = 8 * 60 * 60
 }
 
 resource "vault_jwt_auth_backend" "openshift" {
@@ -67,4 +67,58 @@ resource "vault_jwt_auth_backend_role" "openshift" {
 
   token_policies = ["create_child_token", "update_approle"]
   token_max_ttl  = "900"
+}
+
+# --- Config for JWT/OIDC auth used by Ansible Automation Platform (AAP 2.7) ---
+# The AAP gateway acts as an OIDC IdP: at job launch it mints a short-lived,
+# gateway-signed "workload identity" JWT describing the *job* (organization,
+# inventory, job template, project, launched_by, ...). Jobs using the
+# "HashiCorp Vault Secret Lookup (OIDC)" credential present that JWT here
+# instead of a static AppRole secret_id — replacing the approle flow the
+# snow_drift_tickets role uses today.
+# Issuer + JWKS confirmed live from the gateway:
+#   issuer   : https://aap-aap.apps.openshift-01.hashicorp.local/o
+#   jwks_uri : https://aap-aap.apps.openshift-01.hashicorp.local/o/.well-known/jwks.json
+resource "vault_jwt_auth_backend" "aap" {
+  description        = "JWT/OIDC backend for AAP workload identity (AAP 2.7)"
+  path               = "jwt-aap"
+  oidc_discovery_url = "https://aap-aap.apps.openshift-01.hashicorp.local/o"
+  bound_issuer       = "https://aap-aap.apps.openshift-01.hashicorp.local/o"
+}
+
+resource "vault_jwt_auth_backend_role" "aap" {
+  backend   = vault_jwt_auth_backend.aap.path
+  role_name = "aap-automation"
+  role_type = "jwt"
+
+  # AAP stamps the credential's Vault URL into the JWT `aud` claim
+  # (awx jobs.py: audience = source_credential.get_input('url')), so this must
+  # equal the Server URL configured on the AAP OIDC credential.
+  bound_audiences = ["https://vault.hashicorp.local:8200"]
+
+  # Authorize only jobs in the "Default" org running against "Demo Inventory".
+  # (Teams are not part of the workload-identity claim set — organization /
+  # inventory / job_template are the available structural scopes.)
+  bound_claims_type = "string"
+  bound_claims = {
+    aap_controller_organization_name = "Default"
+    aap_controller_inventory_name    = "Demo Inventory"
+  }
+
+  # `sub` is the gateway-composed workload subject; used for the Vault entity
+  # alias name (identity/audit), not for authorization.
+  user_claim = "sub"
+
+  # Surface job context onto the issued Vault token for audit / policy templating.
+  claim_mappings = {
+    aap_controller_organization_name = "aap_org"
+    aap_controller_inventory_name    = "aap_inventory"
+    aap_controller_job_template_name = "aap_job_template"
+    aap_controller_launched_by_name  = "aap_launched_by"
+    aap_controller_job_id            = "aap_job_id"
+  }
+
+  token_policies = ["read_kv"]
+  token_ttl      = 20 * 60 # 20m — the secret lookup runs at job start; keep short
+  token_max_ttl  = 60 * 60
 }


### PR DESCRIPTION
Adds a `jwt-aap` auth backend + `aap-automation` role so AAP 2.7 jobs can authenticate to Vault with a per-job, gateway-signed **workload-identity JWT** instead of the static AppRole `secret_id` the `snow_drift_tickets` role uses today.

## What's added (`auth_jwt.tf`)
- **`vault_jwt_auth_backend.aap`** (path `jwt-aap`) trusting the AAP gateway OIDC IdP. Issuer/JWKS verified live: `https://aap-aap.apps.openshift-01.hashicorp.local/o` (+ `/o/.well-known/jwks.json`, RS256).
- **`vault_jwt_auth_backend_role.aap`** (`aap-automation`):
  - `bound_audiences = ["https://vault.hashicorp.local:8200"]` — AAP sets the JWT `aud` to the credential's Server URL (`awx jobs.py: audience = source_credential.get_input('url')`).
  - `bound_claims` = `aap_controller_organization_name: Default` + `aap_controller_inventory_name: "Demo Inventory"` (the live values on JT 90 `drift-create-snow-tickets`).
  - `user_claim = sub`, `token_policies = ["read_kv"]`, ttl 20m / max 1h.

## AAP side (already done, for reference)
`FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED` is on; the `HashiCorp Vault Secret Lookup (OIDC)` credential type is available. Configure it with `default_auth_path = jwt-aap`, `jwt_role = aap-automation`, `url = https://vault.hashicorp.local:8200`.

## Apply
Via the `vault-config` TFC workspace (VCS-driven). The `read_kv` policy is reused as requested — note it grants full CRUD on `secrets/*`, broader than read-only; say the word if you'd prefer a tighter read-only policy scoped to `secrets/data/servicenow/*` + `secrets/data/tfc/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)