### PR TITLE
Tighten k8s auth roles to the vault-auth SA; drop dead roles

### DIFF
--- a/auth_k8s.tf
+++ b/auth_k8s.tf
@@ -3,10 +3,10 @@ resource "vault_auth_backend" "this" {
 }
 
 resource "vault_kubernetes_auth_backend_config" "this" {
-  backend            = vault_auth_backend.this.path
+  backend = vault_auth_backend.this.path
 
   kubernetes_host    = var.kubernetes_api
-  kubernetes_ca_cert = base64decode(var.kubernetes_ca_cert) 
+  kubernetes_ca_cert = base64decode(var.kubernetes_ca_cert)
   token_reviewer_jwt = var.token_reviewer_jwt
   issuer             = "https://kubernetes.default.svc"
 }
@@ -14,59 +14,40 @@ resource "vault_kubernetes_auth_backend_config" "this" {
 resource "vault_kubernetes_auth_backend_role" "tfe" {
   backend                          = vault_auth_backend.this.path
   role_name                        = "tfe"
-  bound_service_account_names      = ["*"]
+  bound_service_account_names      = ["vault-auth"]
   bound_service_account_namespaces = ["tfe"]
   token_ttl                        = 259200
   token_policies                   = ["default", "create_pki"]
-  audience = "vault"
+  audience                         = "vault"
 }
 
 resource "vault_kubernetes_auth_backend_role" "aap" {
   backend                          = vault_auth_backend.this.path
   role_name                        = "aap"
-  bound_service_account_names      = ["*"]
+  bound_service_account_names      = ["vault-auth"]
   bound_service_account_namespaces = ["aap"]
   token_ttl                        = 259200
   token_policies                   = ["default", "sign_ssh", "create_pki"]
-  audience = "https://kubernetes.default.svc"
-}
-
-resource "vault_kubernetes_auth_backend_role" "awx" {
-  backend                          = vault_auth_backend.this.path
-  role_name                        = "awx"
-  bound_service_account_names      = ["*"]
-  bound_service_account_namespaces = ["awx"]
-  token_ttl                        = 259200
-  token_policies                   = ["default", "sign_ssh", "create_pki"]
-  audience = "https://kubernetes.default.svc"
+  audience                         = "https://kubernetes.default.svc"
 }
 
 resource "vault_kubernetes_auth_backend_role" "gitlab" {
   backend                          = vault_auth_backend.this.path
   role_name                        = "gitlab"
-  bound_service_account_names      = ["*"]
+  bound_service_account_names      = ["vault-auth"]
   bound_service_account_namespaces = ["gitlab"]
   token_ttl                        = 259200
-  token_policies                   = ["default",  "create_pki"]
-  audience = "https://kubernetes.default.svc"
+  token_policies                   = ["default", "create_pki"]
+  audience                         = "https://kubernetes.default.svc"
 }
 
 resource "vault_kubernetes_auth_backend_role" "keycloak" {
   backend                          = vault_auth_backend.this.path
   role_name                        = "keycloak"
-  bound_service_account_names      = ["*"]
+  bound_service_account_names      = ["vault-auth"]
   bound_service_account_namespaces = ["keycloak"]
   token_ttl                        = 259200
   token_policies                   = ["default", "create_pki"]
-  audience = "https://kubernetes.default.svc"
+  audience                         = "https://kubernetes.default.svc"
 }
 
-resource "vault_kubernetes_auth_backend_role" "vault_live_secrets_demo" {
-  backend                          = vault_auth_backend.this.path
-  role_name                        = "vault-live-secrets-demo"
-  bound_service_account_names      = ["*"]
-  bound_service_account_namespaces = ["vault-live-secrets-demo"]
-  token_ttl                        = 259200
-  token_policies                   = ["default", "read_kv"]
-  audience = "https://kubernetes.default.svc"
-}


### PR DESCRIPTION
## What
- Tighten `bound_service_account_names` from `["*"]` to `["vault-auth"]` on the **tfe, aap, gitlab, keycloak** kubernetes auth roles.
- Remove the orphaned **awx** and **vault-live-secrets-demo** roles (their namespaces no longer exist; awx is superseded by AAP).

## Why (A4)
`["*"]` lets *any* ServiceAccount in the bound namespace assume the role and receive its Vault policies — over-privileged. The apps (aap, tfe) authenticate with the `vault-auth` SA (confirmed from the live `VaultAuth` CRs).

## Validation (against live Vault, before merge)
- **aap**: `vault-auth` SA login → OK, policies `create_pki/default/sign_ssh`. A `default` SA login **currently succeeds** (the over-permission this PR removes).
- **tfe**: `vault-auth` SA login (audience `vault`) → OK, policies `create_pki/default`.
- Both live `VaultAuth` CRs are `valid=true`. Since the tightened binding explicitly includes `vault-auth`, the apps keep authenticating; only non-`vault-auth` SAs get rejected.

## Apply path
The `vault-config` TFC workspace has **no variables in TFC** — it runs locally with a gitignored `terraform.tfvars` (LDAP/OIDC/domain-admin secrets). Apply with `terraform apply` from a checkout that has that tfvars. Expected plan: **4 role updates (SA binding) + 2 role destroys**, nothing else.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Vault Kubernetes authentication bindings; misalignment with cluster SAs would block app login, though the PR targets the confirmed `vault-auth` SA only.
> 
> **Overview**
> **Tightens Kubernetes auth** so only the `vault-auth` ServiceAccount can use the **tfe, aap, gitlab, and keycloak** roles, replacing the previous `["*"]` binding that allowed any SA in those namespaces to receive the role’s Vault policies.
> 
> **Removes** the unused **awx** and **vault-live-secrets-demo** `vault_kubernetes_auth_backend_role` resources. Minor formatting-only edits elsewhere in `auth_k8s.tf`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7259dd7d0bb018647aff6fcb56a15251adc0d4da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->